### PR TITLE
Fetch and Display Missions Data with Redux Integration

### DIFF
--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -26,7 +26,7 @@ const MissionList = () => {
   }
 
   return (
-    <div data-testid="mission-item">
+    <div className="container-fluid ms-5 me-5" data-testid="mission-item">
       <table className="table table-bordered table-striped">
         <thead className="tableHead">
           <tr>
@@ -47,7 +47,7 @@ const MissionList = () => {
               </td>
               <td>
                 {mission.reserved ? (
-                  <button type="button" className="button-leave btn btn-danger" onClick={() => handleLeaveMission(mission.mission_id)}>
+                  <button type="button" className="btn btn-outline-danger" onClick={() => handleLeaveMission(mission.mission_id)}>
                     Leave Mission
                   </button>
                 ) : (

--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -26,16 +26,16 @@ const MissionList = () => {
   }
 
   return (
-    <div className="missionsCont" data-testid="mission-item">
+    <div data-testid="mission-item">
       <table className="table table-bordered table-striped">
         <thead className="tableHead">
           <tr>
-            <th className="mission">Mission</th>
-            <th className="desc">Description</th>
-            <th className="status">Status</th>
+            <th>Mission</th>
+            <th>Description</th>
+            <th>Status</th>
           </tr>
         </thead>
-        <tbody className="tableBody">
+        <tbody>
           {missions.map((mission) => (
             <tr key={mission.mission_id}>
               <td>{mission.mission_name}</td>

--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -1,7 +1,71 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchMissions, joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
-const Missions = () => (
-  <div>Missions starts here</div>
-);
+const MissionList = () => {
+  const missions = useSelector((state) => state.missions.missions);
+  const loading = useSelector((state) => state.missions.loading);
+  const dispatch = useDispatch();
 
-export default Missions;
+  useEffect(() => {
+    if (missions.length === 0) {
+      dispatch(fetchMissions());
+    }
+  }, [dispatch, missions]);
+
+  const handleJoinMission = (missionId) => {
+    dispatch(joinMission({ missionId }));
+  };
+
+  const handleLeaveMission = (missionId) => {
+    dispatch(leaveMission({ missionId }));
+  };
+
+  if (loading === 'idle') {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="missionsCont" data-testid="mission-item">
+      <table className="table table-bordered table-striped">
+        <thead className="tableHead">
+          <tr>
+            <th className="mission">Mission</th>
+            <th className="desc">Description</th>
+            <th className="status">Status</th>
+          </tr>
+        </thead>
+        <tbody className="tableBody">
+          {missions.map((mission) => (
+            <tr key={mission.mission_id}>
+              <td>{mission.mission_name}</td>
+              <td>{mission.description}</td>
+              <td>
+                <div className={`member ${mission.reserved ? 'activeMem' : 'not-member'}`}>
+                  {mission.reserved ? 'Active Member' : 'NOT A MEMBER'}
+                </div>
+              </td>
+              <td>
+                {mission.reserved ? (
+                  <button type="button" className="button-leave btn btn-danger" onClick={() => handleLeaveMission(mission.mission_id)}>
+                    Leave Mission
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="joinM btn btn-primary"
+                    onClick={() => handleJoinMission(mission.mission_id)}
+                  >
+                    Join Mission
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default MissionList;

--- a/src/components/Missions.jsx
+++ b/src/components/Missions.jsx
@@ -30,18 +30,18 @@ const MissionList = () => {
       <table className="table table-bordered table-striped">
         <thead className="tableHead">
           <tr>
-            <th>Mission</th>
-            <th>Description</th>
-            <th>Status</th>
+            <th><strong>Mission</strong></th>
+            <th><strong>Description</strong></th>
+            <th><strong>Status</strong></th>
           </tr>
         </thead>
         <tbody>
           {missions.map((mission) => (
             <tr key={mission.mission_id}>
-              <td>{mission.mission_name}</td>
-              <td>{mission.description}</td>
+              <td className="col-1"><strong>{mission.mission_name}</strong></td>
+              <td className="col-8">{mission.description}</td>
               <td>
-                <div className={`member ${mission.reserved ? 'activeMem' : 'not-member'}`}>
+                <div className={`member ${mission.reserved ? 'btn btn-primary px-3' : 'btn btn-secondary px-3'}`}>
                   {mission.reserved ? 'Active Member' : 'NOT A MEMBER'}
                 </div>
               </td>
@@ -53,7 +53,7 @@ const MissionList = () => {
                 ) : (
                   <button
                     type="button"
-                    className="joinM btn btn-primary"
+                    className="joinM btn btn-light px-3"
                     onClick={() => handleJoinMission(mission.mission_id)}
                   >
                     Join Mission

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,60 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const initialState = {
+  missions: [],
+  selectedMission: null,
+  loading: false,
+  error: null,
+};
+
+export const fetchMissions = createAsyncThunk(
+  'missions/fetchMissions',
+  async () => {
+    try {
+      const response = await axios.get('https://api.spacexdata.com/v4/missions');
+      return response.data;
+    } catch (error) {
+      return error.response.data;
+    }
+  },
+);
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {
+    setSelectedMission: (state, action) => {
+      state.selectedMission = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissions.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(fetchMissions.fulfilled, (state, action) => {
+      state.loading = false;
+      const missions = action.payload;
+
+      const missionItems = missions.map((mission) => ({
+        id: mission.id,
+        name: mission.name,
+        description: mission.description,
+        image: mission.flickr_images[0],
+      }));
+      state.missions = missionItems;
+    });
+    builder.addCase(fetchMissions.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
+    });
+  },
+});
+
+export const getAllMissions = (state) => state.missions.missions;
+export const getSelectedMission = (state) => state.missions.selectedMission;
+export const getLoading = (state) => state.missions.loading;
+export const getError = (state) => state.missions.error;
+
+export const { setSelectedMission } = missionsSlice.actions;
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rocketsReducer from './rockets/rocketsSlice';
+import missionsReducer from './missions/missionsSlice';
 
 const store = configureStore({
   reducer: {
     rockets: rocketsReducer,
+    missions: missionsReducer,
   },
 });
 


### PR DESCRIPTION
This pull request implements the functionality to fetch data from the SpaceX Missions API and store the selected data in the Redux store. It also integrates the use of the useSelector Redux Hook to render lists of missions in the corresponding routes. Additionally, it provides styling options using React Bootstrap, a popular UI library, to enhance the user interface.

**Changes Made:**

- Added logic to fetch data from the Missions API endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- Dispatched an action to store the selected data in the Redux store, including the mission_id, mission_name, and description fields.
- Ensured that data is only dispatched once and not added to the store on every re-render.
- Utilized the useSelector Redux Hook to select the necessary state slices in order to render lists of missions in the corresponding routes.
- Introduced React Bootstrap, a popular UI library, to streamline and enhance the styling of the application.
- Rendered a table to display the missions' data based on the provided design.
- Implement mission leaving 
- Implement mission joining
- Implement  switch badges for Missions

Thank you for considering this pull request. Your feedback and suggestions are welcome. Let me know if there's anything I can do to further improve the implementation.

