### PR TITLE
Render List of Joined Missions on "My Profile" Page

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,22 +1,39 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { getAllRockets } from '../redux/rockets/rocketsSlice';
+import { selectMissions } from '../redux/missions/missionsSlice';
 
 const Profile = () => {
   const rockets = useSelector(getAllRockets);
   const reservedRockets = rockets.filter((rocket) => rocket.reserved);
+  const missions = useSelector(selectMissions);
+  const reservedMissions = missions.filter((mission) => mission.reserved);
 
   return (
     <div className="d-flex justify-content-evenly ">
       <div className="d-flex flex-column w-100 p-3">
         <h2>My Missions</h2>
+        {reservedMissions.length === 0 && <p className="fs-4">You have no missions reserved</p>}
+        <ul className="container-fluid d-flex flex-column justify-content-center ps-0 me-5 list-unstyled">
+          {reservedMissions.map((item) => (
+            <li
+              className="border border-success p-2 border-opacity-25"
+              key={item.name_id}
+            >
+              <p className="mb-0 fs-5">{item.mission_name}</p>
+            </li>
+          ))}
+        </ul>
       </div>
       <div className="d-flex flex-column w-100 p-3">
         <h2>My Rockets</h2>
-        {rockets.length === 0 && <p className="fs-4">You have no rockets reserved</p>}
+        {reservedRockets.length === 0 && <p className="fs-4">You have no rockets reserved</p>}
         <ul className="container-fluid d-flex flex-column justify-content-center ps-0 me-5 list-unstyled">
           {reservedRockets.map((item) => (
-            <li className="border border-success p-2 border-opacity-25" key={item.id}>
+            <li
+              className="border border-success p-2 border-opacity-25"
+              key={item.id}
+            >
               <p className="mb-0 fs-5">{item.name}</p>
             </li>
           ))}

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -23,11 +23,15 @@ const missionsSlice = createSlice({
   reducers: {
     joinMission: (state, action) => {
       const { missionId } = action.payload;
-      state.missions = state.missions.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: true } : mission));
+      state.missions = state.missions.map(
+        (mission) => (mission.mission_id === missionId ? { ...mission, reserved: true } : mission),
+      );
     },
     leaveMission: (state, action) => {
       const { missionId } = action.payload;
-      state.missions = state.missions.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: false } : mission));
+      state.missions = state.missions.map(
+        (mission) => (mission.mission_id === missionId ? { ...mission, reserved: false } : mission),
+      );
     },
   },
   extraReducers: (builder) => {

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -17,19 +17,17 @@ const initialState = {
   loading: 'idle',
 };
 
-const missionsSlices = createSlice({
+const missionsSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {
     joinMission: (state, action) => {
       const { missionId } = action.payload;
-      state.missions = state.missions.map((mission) => (
-        mission.mission_id === missionId ? { ...mission, reserved: true } : mission));
+      state.missions = state.missions.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: true } : mission));
     },
     leaveMission: (state, action) => {
       const { missionId } = action.payload;
-      state.missions = state.missions.map((mission) => (
-        mission.mission_id === missionId ? { ...mission, reserved: false } : mission));
+      state.missions = state.missions.map((mission) => (mission.mission_id === missionId ? { ...mission, reserved: false } : mission));
     },
   },
   extraReducers: (builder) => {
@@ -46,5 +44,8 @@ const missionsSlices = createSlice({
   },
 });
 
-export const { joinMission, leaveMission } = missionsSlices.actions;
-export default missionsSlices.reducer;
+export const { joinMission, leaveMission } = missionsSlice.actions;
+
+export const selectMissions = (state) => state.missions.missions;
+
+export default missionsSlice.reducer;


### PR DESCRIPTION
This pull request adds a feature to the "My Profile" page, displaying a list of joined missions using the filter() function. Users will now have easy access to their joined missions, promoting engagement and a sense of accomplishment.

**Details:**

- Updated "My Profile" page component to incorporate a new section for joined missions.
- Implemented filter() function to extract joined missions from mission data.

Please review this pull request and provide feedback on the implementation, code quality, and user experience. Your input is highly appreciated.

